### PR TITLE
fix overwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.1 - (2026-05-07)
+
+### Fix
+* Fixed `insert_overwrite` strategy silently overwriting all partitions instead of only affected ones when both `partition_by` and `tbm_filter_mode` are set (no data corruption, overwork only)
+
 ## 1.0.0 - (2026-01-16)
 
 ### Release

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Add one of the following to your `packages.yml`:
 ```yaml
 packages:
   - git: "https://github.com/vladimir-vvalov/tbmacro.git"
-    revision: v1.0.0
+    revision: v1.0.1
 ```
 
 **Option 2: Tarball**

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'tbmacro'
-version: '1.0.0'
+version: '1.0.1'
 config-version: 2
 
 require-dbt-version: [">=1.8.0", "<2.0.0"]

--- a/macros/materialization/tbmacro_column_helpers.sql
+++ b/macros/materialization/tbmacro_column_helpers.sql
@@ -48,7 +48,7 @@
 {%- if values_list is none or not values_list -%}
       {%- set is_empty = true -%}
     {%- else -%}
-    {%- set sql -%}}
+    {%- set sql -%}
     and {{ key }} in (
       {%- for item in values_list -%}
       {{ tbmacro.tbmacro_quote(item, tbm_config.quote_values) }}{{ "," if not loop.last }}

--- a/macros/materialization/tbmacro_incremental.sql
+++ b/macros/materialization/tbmacro_incremental.sql
@@ -102,7 +102,7 @@
     {#-- Create secondary temporary view for union selection with out of range data if strategy == 'insert_overwrite' --#}
     {%- if strategy == 'insert_overwrite' and is_existing_relation == true and tbm_config.mode is not none and tbm_config.limit is none -%}
       {%- set filter_partition_by_dict = tbmacro.tbmacro_filter_partition_by(tmp_relation, tbm_config) -%}
-      {%- set filter_partition_by = filter_partition_by_dict.sql.value -%}
+      {%- set filter_partition_by = filter_partition_by_dict.sql -%}
       {%- set is_empty_partition_by = filter_partition_by_dict.is_empty -%}
 
       {#-- Check if selection is empty due to partition_by filter --#}


### PR DESCRIPTION
* Fixed `insert_overwrite` strategy silently overwriting all partitions instead of only affected ones when both `partition_by` and `tbm_filter_mode` are set (no data corruption, overwork only)
